### PR TITLE
Fix hidden modal interference

### DIFF
--- a/script.js
+++ b/script.js
@@ -174,7 +174,10 @@ function cleanupCurrentVideo() {
 // Función para cerrar todos los modales
 function closeAllModals() {
     document.querySelectorAll('.modal').forEach(modal => {
-        closeModal(modal);
+        const display = window.getComputedStyle(modal).display;
+        if (display === 'flex' || display === 'block') {
+            closeModal(modal);
+        }
     });
 }
 


### PR DESCRIPTION
## Summary
- ensure closeAllModals only closes modals that are currently visible, preventing accidental hiding of new modals

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d136b04588328ad1c4a78ee5576c5